### PR TITLE
Custom verovio build

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,11 +11,11 @@ jobs:
 
         steps:
             -
-                name: Build docker image
-                run: docker build -t verovio-script -f Dockerfile .
-            -
                 name: Checkout
                 uses: actions/checkout@v3
+            -
+                name: Build docker image
+                run: docker build -t verovio-script -f Dockerfile .
             -
                 name: Copy wasm
                 run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,9 +20,6 @@ jobs:
                   ref: gh-pages
             -
                 name: Copy wasm
-                run: docker build -t verovio-script -f Dockerfile .
-            -
-                name: Copy wasm
                 run: |
                     docker create --name dummy verovio-script
                     docker cp dummy:/app/verovio-toolkit-wasm.js scripts/verovio-toolkit-wasm.js

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -16,11 +16,10 @@ jobs:
             -
                 name: Checkout
                 uses: actions/checkout@v3
-                with:
-                  ref: gh-pages
             -
                 name: Copy wasm
                 run: |
+                    git checkout gh-pages
                     docker create --name dummy verovio-script
                     docker cp dummy:/app/verovio-toolkit-wasm.js scripts/verovio-toolkit-wasm.js
                     docker rm -f dummy

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,6 +11,11 @@ jobs:
 
         steps:
             -
+                name: Checkout
+                uses: actions/checkout@v3
+                with:
+                  ref: gh-pages
+            -
                 name: Test
                 run: |
                     echo "Hello world" > scripts/verovio-toolkit-wasm.js

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -11,14 +11,22 @@ jobs:
 
         steps:
             -
+                name: Build docker image
+                run: docker build -t verovio-script -f Dockerfile .
+            -
                 name: Checkout
                 uses: actions/checkout@v3
                 with:
                   ref: gh-pages
             -
-                name: Test
+                name: Copy wasm
+                run: docker build -t verovio-script -f Dockerfile .
+            -
+                name: Copy wasm
                 run: |
-                    echo "Hello world" > scripts/verovio-toolkit-wasm.js
+                    docker create --name dummy verovio-script
+                    docker cp dummy:/app/verovio-toolkit-wasm.js scripts/verovio-toolkit-wasm.js
+                    docker rm -f dummy
             -
                 name: Commit changes
                 run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,24 @@
+name: Update verovio
+
+on:
+    schedule:
+        - cron:  '0 0 * * *'
+    workflow_dispatch: ~
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            -
+                name: Test
+                run: |
+                    echo "Hello world" > scripts/verovio-toolkit-wasm.js
+            -
+                name: Commit changes
+                run: |
+                    git config --global user.name "Wolfgang Drescher"
+                    git config --global user.email "drescher.wolfgang+git@gmail.com"
+                    git diff --quiet && git diff --staged --quiet || git commit -am "Update"
+                    git push
+

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -13,6 +13,8 @@ jobs:
             -
                 name: Checkout
                 uses: actions/checkout@v3
+                with:
+                    fetch-depth: 0
             -
                 name: Build docker image
                 run: docker build -t verovio-script -f Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM emscripten/emsdk:latest AS builder
+
+LABEL maintainer="drescher.wolfgang@gmail.com"
+
+WORKDIR /usr/local
+
+# craigsapp/humlib
+RUN git clone https://github.com/craigsapp/humlib.git
+
+# rism-digital/verovio
+RUN git clone -b develop-humdrum https://github.com/rism-digital/verovio.git
+RUN cp /usr/local/humlib/include/humlib.h /usr/local/verovio/include/hum/humlib.h && \
+    cp /usr/local/humlib/src/humlib.cpp /usr/local/verovio/src/hum/humlib.cpp
+RUN (cd verovio/emscripten && ./buildToolkit -w)
+
+
+
+FROM ubuntu:jammy
+
+LABEL maintainer="drescher.wolfgang@gmail.com"
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/verovio/emscripten/build/verovio-toolkit-hum.js ./verovio-toolkit-wasm.js
+


### PR DESCRIPTION
If you want this feature make sure it will not make problems with the current build action.

This PR will add a GitHub action that runs as a cronjob midnight every day. It will make a custom verovio build based on the `develop-humdrum` branch of `rism-digital/verovio` and `master` of `craigsapp/humlib`.

You should change `git config --global user.name`  and `user.email` in the GitHub action as well as `LABEL maintainer` in the Dockerfile to your name and email.

You can also trigger this action manually (`workflow_dispatch`).

Currently there is no way to listen to push events of other repositories (https://stackoverflow.com/a/58468828/9009012)